### PR TITLE
Update README.md to fix the Discord url

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Smart contracts are implemented in [Rust](https://www.rust-lang.org/) + [Casper 
 
 ### ❓Have questions?
 
-Go to the `#dev-discussion` channel [on Discord](https://discord.gg/casperblockchain)
+Go to the `#dev-discussion` channel [on Discord](https://discord.gg/caspernetwork)
 
 ### 🪦 Errors ?
 


### PR DESCRIPTION
The new official url is https://discord.gg/caspernetwork